### PR TITLE
Fixed a memory leak caused by the BirthdateCoordinator being retained

### DIFF
--- a/Sources/CTR/Interface/Holder/Dashboard/HolderDashboardViewController.swift
+++ b/Sources/CTR/Interface/Holder/Dashboard/HolderDashboardViewController.swift
@@ -35,6 +35,12 @@ class HolderDashboardViewController: BaseViewController {
 		
 		view = sceneView
 	}
+    
+	override func viewDidAppear(_ animated: Bool) {
+		super.viewDidAppear(animated)
+		
+		viewModel.start()
+	}
 	
 	override func viewDidLoad() {
 		

--- a/Sources/CTR/Interface/Holder/Dashboard/HolderDashboardViewModel.swift
+++ b/Sources/CTR/Interface/Holder/Dashboard/HolderDashboardViewModel.swift
@@ -261,6 +261,10 @@ class HolderDashboardViewModel: Logging {
 		cryptoManager?.removeCredential()
 		checkQRValidity()
 	}
+    
+	func start() {
+		coordinator?.navigateBackToStart()
+	}
 
 	/// Formatter to print
 	private lazy var printDateFormatter: DateFormatter = {

--- a/Sources/CTR/Interface/Holder/HolderCoordinator.swift
+++ b/Sources/CTR/Interface/Holder/HolderCoordinator.swift
@@ -301,6 +301,9 @@ extension HolderCoordinator: HolderCoordinatorDelegate {
 
 	/// Navigate to the start fo the holder flow
 	func navigateBackToStart() {
+		childCoordinators.forEach {
+			removeChildCoordinator($0)
+		}
 
 		sidePanel?.selectedViewController?.dismiss(animated: true, completion: nil)
 		(sidePanel?.selectedViewController as? UINavigationController)?.popToRootViewController(animated: true)


### PR DESCRIPTION
Hi,

After opening the `BirthdateEntryViewController` a few times I noticed a memory leak by the fact that `BirthdateCoordinator` was being kept in memory, even though none of its view controllers were visible. After debugging I found out that the `BirthdateCoordinator` was not being removed from the `HolderCoordinator`'s `childCoordinators`. Ideally a Coordinator would get notified as soon as a child coordinator finishes, however I could not find any precedent in the codebase, so without making too many changes this seemed like the most minimalistic fix in this case. 

I could not find any unintended side-effects by the fact that `navigateBackToStart()` is called every time the `HolderDashboardViewController` appears.