### PR TITLE
Dependabot: Add configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
+
 - package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "08:00"
+    timezone: Europe/Amsterdam
+
+- package-ecosystem: github-actions	
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
Adds configuration to Dependabot that checks if all GitHub Actions used are up to date.